### PR TITLE
Fix/bug blank screen

### DIFF
--- a/src/components/Forms/FormDialog.jsx
+++ b/src/components/Forms/FormDialog.jsx
@@ -7,10 +7,16 @@ import DialogTitle from "@material-ui/core/DialogTitle";
 import TextInput from "./TextInput";
 
 function FormDialog() {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
   return (
     <Dialog
-      open={this.props.open}
-      onClose={this.props.handleClose}
+      open={open}
+      onClose={handleClose}
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
     >
@@ -23,10 +29,8 @@ function FormDialog() {
         <TextInput />
       </DialogContent>
       <DialogActions>
-        <Button onClick={this.props.handleClose}>依頼する</Button>
-        <Button onClick={this.props.handleClose} autoFocus>
-          戻る
-        </Button>
+        <Button onClick={handleClose}>依頼する</Button>
+        <Button onClick={handleClose}>戻る</Button>
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
@daiki-tadokoro 
## 事象
 29b67d3 の修正後、解答欄と質問欄が表示されるはずがborder部分のみ表示されるエラーが発生しました。

<img width="1440" alt="スクリーンショット 2023-03-06 23 51 53" src="https://user-images.githubusercontent.com/102593089/223328002-11a099b4-34b4-4f40-936f-ac7b1c2e6912.png">

## 考えられる原因 
・App.jsxでクラスコンポーネントから関数コンポーネントに移行する際に
https://github.com/aoi-0358/redelivery-app/blob/main/src/App.jsx#:~:text=%7D%3B-,//%20componentDidMount()%20%7B,//%20%7D,-return%20(
をコメントアウトして描画されなくなっているのが原因と考えられます。
## 対応
この記事を参照しましたが、どのように実装するのか分からない状況です。
https://nekorokkekun.hatenablog.com/entry/2019/10/13/180740