### PR TITLE
[FYI]ダイアログの表示/非表示の機能修正

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,14 +42,14 @@ function App() {
     });
   };
   // 回答が選択された時に呼ばれる関数
-const selectedAnswer = (selectedAnswer, nextQuestionId) => {
+  const selectedAnswer = (selectedAnswer, nextQuestionId) => {
     switch (true) {
       case nextQuestionId === "init":
         setTimeout(() => displayNextQuestion(nextQuestionId), 500);
         break;
 
       case nextQuestionId === "contact":
-        handleClickOpen();
+        // handleClickOpen();
         break;
 
       default:
@@ -72,13 +72,6 @@ const selectedAnswer = (selectedAnswer, nextQuestionId) => {
     }
   };
 
-  const handleClickOpen = () => {
-    dataset({ open: true });
-  };
-  const handleClose = () => {
-    dataset({ open: false });
-  };
-
   // componentDidMount() {
   //   const initAnswer = "";
   //   selectAnswer(initAnswer, currentId);
@@ -96,11 +89,7 @@ const selectedAnswer = (selectedAnswer, nextQuestionId) => {
       <div className="c-box">
         <Chats chats={chats} />
         <AnswersList answers={answers} select={setSelectedAnswers} />
-        <FormDialog
-          open={isOpen}
-          handleClose={handleClose}
-          selectedAnswers={selectedAnswers}
-        />
+        <FormDialog selectedAnswers={selectedAnswers} />
       </div>
     </section>
   );

--- a/src/components/Forms/FormDialog.jsx
+++ b/src/components/Forms/FormDialog.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
@@ -7,32 +7,39 @@ import DialogTitle from "@material-ui/core/DialogTitle";
 import TextInput from "./TextInput";
 
 function FormDialog() {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
 
   const handleClose = () => {
     setOpen(false);
   };
 
   return (
-    <Dialog
-      open={open}
-      onClose={handleClose}
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
-    >
-      <DialogTitle id="alert-dialog-title">
-        この内容でお間違いなければ
-        <br />
-        下の『依頼する』を選択してください
-      </DialogTitle>
-      <DialogContent>
-        <TextInput />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose}>依頼する</Button>
-        <Button onClick={handleClose}>戻る</Button>
-      </DialogActions>
-    </Dialog>
+    <>
+      <button onClick={handleClickOpen}>モーダルを開くボタン</button>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          この内容でお間違いなければ
+          <br />
+          下の『依頼する』を選択してください
+        </DialogTitle>
+        <DialogContent>
+          <TextInput />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>依頼する</Button>
+          <Button onClick={handleClose}>戻る</Button>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 }
 


### PR DESCRIPTION
## 事象

ダイアログが表示/非表示が正常に機能していなかった。


### 背景

Dialogコンポーネントの`open`が`true`になる処理が存在しなかった。


### 解決方法

src/components/Forms/FormDialog.jsx　内で
Dialogの表示/非表示を管理する `isOpen` の `useState` を保持し
同ファイル内に表示を行うボタンを追加することで解決。　https://github.com/aoi-0358/redelivery-app/commit/94dfbaa7b2b0f87026d2c7bf2373944561bd57ce